### PR TITLE
Switch todos to REST API

### DIFF
--- a/TodoScreen.tsx
+++ b/TodoScreen.tsx
@@ -9,9 +9,7 @@ import {
   ScrollView,
   Dimensions
 } from 'react-native';
-import { generateClient } from 'aws-amplify/api';
-import { createTodo } from './src/graphql/mutations';
-import { listTodos } from './src/graphql/queries';
+import { API } from 'aws-amplify';
 
 const { width: screenWidth } = Dimensions.get('window');
 const isTablet = screenWidth >= 768;
@@ -34,8 +32,6 @@ interface FormState {
 }
 
 const initialState: FormState = { name: '', description: '' };
-const client = generateClient();
-
 const TodoScreen = () => {
   const [formState, setFormState] = useState<FormState>(initialState);
   const [todos, setTodos] = useState<Todo[]>([]);
@@ -50,11 +46,8 @@ const TodoScreen = () => {
 
   async function fetchTodos() {
     try {
-      const todoData = await client.graphql({
-        query: listTodos
-      });
-      const todos = todoData.data.listTodos.items;
-      setTodos(todos);
+      const fetched = await API.get('TodoAPI', '/todos');
+      setTodos(fetched);
     } catch (err) {
       console.log('error fetching todos:', err);
     }
@@ -64,14 +57,8 @@ const TodoScreen = () => {
     try {
       if (!formState.name || !formState.description) return;
       const todo = { ...formState };
-      setTodos([...todos, todo]);
+      await API.post('TodoAPI', '/todos', { body: todo });
       setFormState(initialState);
-      await client.graphql({
-        query: createTodo,
-        variables: {
-          input: todo
-        }
-      });
       // Refresh the list after adding
       fetchTodos();
     } catch (err) {

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,36 @@
+const http = require('http');
+
+let todos = [];
+
+const server = http.createServer((req, res) => {
+  const { method, url } = req;
+  if (url === '/todos' && method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(todos));
+  } else if (url === '/todos' && method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        const todo = { id: Date.now().toString(), ...JSON.parse(body) };
+        todos.push(todo);
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(todo));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'Invalid JSON' }));
+      }
+    });
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Not Found' }));
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`TodoAPI running on port ${PORT}`);
+});
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "server": "node api/server.js"
   },
   "dependencies": {
     "@aws-amplify/react-native": "^1.1.10",

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -1,0 +1,12 @@
+const awsmobile = {
+  aws_project_region: 'us-east-1',
+  aws_cloud_logic_custom: [
+    {
+      name: 'TodoAPI',
+      endpoint: 'http://localhost:3000',
+      region: 'us-east-1'
+    }
+  ]
+};
+
+export default awsmobile;


### PR DESCRIPTION
## Summary
- Replace GraphQL client usage with Amplify REST API calls in `TodoScreen`
- Add simple HTTP server exposing `/todos` REST endpoints
- Configure Amplify to point to new `TodoAPI` endpoint and add server run script

## Testing
- `npm test` *(fails: Missing script "test")*
- `node api/server.js` *(server starts then stops)*

------
https://chatgpt.com/codex/tasks/task_e_6899d3a70870832c8511ba4031af58b1