### PR TITLE
Store ID token after sign-in and add authorized API utilities

### DIFF
--- a/LogIn.tsx
+++ b/LogIn.tsx
@@ -4,6 +4,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from './App';
 import { useNavigation } from '@react-navigation/native';
 import { signIn, fetchAuthSession } from 'aws-amplify/auth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type LogInNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -147,11 +148,26 @@ export default function LogIn() {
       const { isSignedIn } = await signIn({ username: email, password });
       
       console.log('SignIn result:', { isSignedIn });
-      
+
       if (isSignedIn) {
+        // Fetch the current session to get tokens
+        const session = await fetchAuthSession();
+        const idToken = session.tokens?.idToken?.toString();
+
+        if (idToken) {
+          try {
+            await AsyncStorage.setItem('idToken', idToken);
+            console.log('ID token stored successfully');
+          } catch (storageError) {
+            console.error('Error storing ID token:', storageError);
+          }
+        } else {
+          console.log('No ID token returned from session');
+        }
+
         // User is successfully authenticated and in Cognito pool
         console.log('Login successful, navigating to Dashboard...');
-        
+
         // Navigate directly to Dashboard
         console.log('Attempting to navigate to Dashboard...');
         navigation.navigate('Dashboard');

--- a/OAuthHandler.tsx
+++ b/OAuthHandler.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from './App';
 import { fetchAuthSession, signIn, signOut } from 'aws-amplify/auth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type OAuthNavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -129,16 +130,9 @@ export default function OAuthHandler() {
 
   const storeTokens = async (tokens: OAuthTokens) => {
     try {
-      // Store tokens securely
-      // You can use @react-native-async-storage/async-storage or expo-secure-store
-      console.log('Storing tokens securely...');
-      
-      // For now, we'll just log them (in production, use secure storage)
-      console.log('Access Token:', tokens.accessToken.substring(0, 20) + '...');
-      console.log('ID Token:', tokens.idToken.substring(0, 20) + '...');
-      console.log('Refresh Token:', tokens.refreshToken.substring(0, 20) + '...');
-      console.log('Expires In:', new Date(tokens.expiresIn));
-      
+      await AsyncStorage.setItem('accessToken', tokens.accessToken);
+      await AsyncStorage.setItem('idToken', tokens.idToken);
+      console.log('Tokens stored');
     } catch (error) {
       console.error('Token storage error:', error);
     }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,47 @@
+import { API } from 'aws-amplify';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const TOKEN_KEY = 'idToken';
+
+const getAuthHeader = async () => {
+  const session = await fetchAuthSession();
+  const token = session.tokens?.idToken?.toString() || '';
+  if (token) {
+    await AsyncStorage.setItem(TOKEN_KEY, token);
+  }
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+export const apiGet = async (
+  apiName: string,
+  path: string,
+  options: any = {}
+) => {
+  const headers = await getAuthHeader();
+  return API.get(apiName, path, {
+    ...options,
+    headers: { ...(options.headers || {}), ...headers }
+  });
+};
+
+export const apiPost = async (
+  apiName: string,
+  path: string,
+  options: any = {}
+) => {
+  const headers = await getAuthHeader();
+  return API.post(apiName, path, {
+    ...options,
+    headers: { ...(options.headers || {}), ...headers }
+  });
+};
+
+export const refreshToken = async () => {
+  const session = await fetchAuthSession();
+  const idToken = session.tokens?.idToken?.toString();
+  if (idToken) {
+    await AsyncStorage.setItem(TOKEN_KEY, idToken);
+  }
+  return idToken;
+};


### PR DESCRIPTION
## Summary
- fetch ID token after successful sign-in and persist to AsyncStorage
- update OAuth handler and test login to save tokens
- add helper for API.get/API.post that injects Authorization header and refreshes session tokens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899da0af690832c863b0e2fee427dce